### PR TITLE
Four new endpoints 

### DIFF
--- a/actions/gate/gate.go
+++ b/actions/gate/gate.go
@@ -12,6 +12,7 @@ import (
 
 var notificationGate []interface{}
 var notificationToShow []interface{}
+var lastNotificationToShow []interface{}
 
 func SaveNotifications(w http.ResponseWriter, r *http.Request) {
 	var notific interface{}
@@ -62,9 +63,9 @@ func LastNotification(w http.ResponseWriter, r *http.Request) {
 		body, err := ioutil.ReadAll(r.Body)
 
 		common.ErrorHandler(err)
-		common.ClearSlice(&notificationToShow)
+		common.ClearSlice(&lastNotificationToShow)
 
-		notificationToShow = append(notificationToShow, string(body))
+		lastNotificationToShow = append(lastNotificationToShow, string(body))
 		w.Write([]byte(common.JsonStatusOk))
 	}
 	defer r.Body.Close()
@@ -96,7 +97,7 @@ func ShowLastNotification(w http.ResponseWriter, req *http.Request) {
 	if req.Method == http.MethodGet {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		var str string
-		for i, res := range notificationToShow {
+		for i, res := range lastNotificationToShow {
 			str += "<span>" + "_______________________________________________________________" + "</span>" + "<p>"
 			str += "<span>" + strconv.Itoa(i+1) + ")" + fmt.Sprint(res) + "</span>" + "<p>"
 			str += "<span>" + "_______________________________________________________________" + "</span>" + "<p>"

--- a/actions/gate/gate.go
+++ b/actions/gate/gate.go
@@ -56,6 +56,20 @@ func Notification(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 }
 
+func LastNotification(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPost {
+		w.WriteHeader(http.StatusOK)
+		body, err := ioutil.ReadAll(r.Body)
+
+		common.ErrorHandler(err)
+		common.ClearSlice(&notificationToShow)
+
+		notificationToShow = append(notificationToShow, string(body))
+		w.Write([]byte(common.JsonStatusOk))
+	}
+	defer r.Body.Close()
+}
+
 func NotificationRedirect(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {
 		http.Redirect(w, r, "127.0.0.1/notification", http.StatusSeeOther)
@@ -73,6 +87,20 @@ func ShowNotification(w http.ResponseWriter, req *http.Request) {
 			str += "<span>" + "_______________________________________________________________" + "</span>" + "<p>"
 		}
 		notificationToShow = nil
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, str)
+	}
+}
+
+func ShowLastNotification(w http.ResponseWriter, req *http.Request) {
+	if req.Method == http.MethodGet {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		var str string
+		for i, res := range notificationToShow {
+			str += "<span>" + "_______________________________________________________________" + "</span>" + "<p>"
+			str += "<span>" + strconv.Itoa(i+1) + ")" + fmt.Sprint(res) + "</span>" + "<p>"
+			str += "<span>" + "_______________________________________________________________" + "</span>" + "<p>"
+		}
 		w.WriteHeader(http.StatusOK)
 		io.WriteString(w, str)
 	}

--- a/actions/solidGate/solidGateMethods.go
+++ b/actions/solidGate/solidGateMethods.go
@@ -33,3 +33,27 @@ func BackSolidGateProd(w http.ResponseWriter, r *http.Request) {
 	}
 	defer r.Body.Close()
 }
+
+func SaveSolidGateProdLast(w http.ResponseWriter, r *http.Request) {
+	var notific interface{}
+	if r.Method == "POST" {
+		w.WriteHeader(http.StatusOK)
+		body, err := ioutil.ReadAll(r.Body)
+		common.ErrorHandler(err)
+		common.ClearSlice(&listNotifications)
+		err = json.Unmarshal(body, &notific)
+		common.ErrorHandler(err)
+		listNotifications = append(listNotifications, notific)
+		w.Write([]byte(common.JsonStatusOk))
+	}
+	defer r.Body.Close()
+}
+
+func BackSolidGateProdLast(w http.ResponseWriter, r *http.Request) {
+	if r.Method == "POST" {
+		w.WriteHeader(http.StatusOK)
+		list, _ := json.Marshal(listNotifications)
+		w.Write([]byte(list))
+	}
+	defer r.Body.Close()
+}

--- a/actions/solidGate/solidGateMethods.go
+++ b/actions/solidGate/solidGateMethods.go
@@ -8,6 +8,7 @@ import (
 )
 
 var listNotifications []interface{}
+var lastNotificationOnGate []interface{}
 
 func SaveSolidGateProd(w http.ResponseWriter, r *http.Request) {
 	var notific interface{}
@@ -40,10 +41,10 @@ func SaveSolidGateProdLast(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		body, err := ioutil.ReadAll(r.Body)
 		common.ErrorHandler(err)
-		common.ClearSlice(&listNotifications)
+		common.ClearSlice(&lastNotificationOnGate)
 		err = json.Unmarshal(body, &notific)
 		common.ErrorHandler(err)
-		listNotifications = append(listNotifications, notific)
+		lastNotificationOnGate = append(lastNotificationOnGate, notific)
 		w.Write([]byte(common.JsonStatusOk))
 	}
 	defer r.Body.Close()
@@ -52,7 +53,7 @@ func SaveSolidGateProdLast(w http.ResponseWriter, r *http.Request) {
 func BackSolidGateProdLast(w http.ResponseWriter, r *http.Request) {
 	if r.Method == "POST" {
 		w.WriteHeader(http.StatusOK)
-		list, _ := json.Marshal(listNotifications)
+		list, _ := json.Marshal(lastNotificationOnGate)
 		w.Write([]byte(list))
 	}
 	defer r.Body.Close()

--- a/main.go
+++ b/main.go
@@ -40,11 +40,17 @@ func main() {
 	r.HandleFunc("/shownotification", gate.ShowNotification)
 	r.HandleFunc("/notificationRedirect", gate.NotificationRedirect)
 
+	r.PathPrefix("/lastNotification").HandlerFunc(gate.LastNotification)
+	r.HandleFunc("/showLastNotifications", gate.ShowLastNotification)
+
 	r.HandleFunc("/savenotification", gate.SaveNotifications)
 	r.HandleFunc("/backnotification", gate.BackNotifications)
 
 	r.HandleFunc("/saveSolid", solidGate.SaveSolidGateProd)
 	r.HandleFunc("/backSolid", solidGate.BackSolidGateProd)
+
+	r.HandleFunc("/saveSolidLast", solidGate.SaveSolidGateProdLast)
+	r.HandleFunc("/backSolidLast", solidGate.BackSolidGateProdLast)
 
 	//VMPI
 	r.HandleFunc("/empty", vmpi.Empty)


### PR DESCRIPTION
Endpoints were added that allow users to store callbacks in the amount of fewer than 40 messages. 
After exceeding 40, the current list will be cleaned. 